### PR TITLE
Fix a warning & log on `debug` channel

### DIFF
--- a/src/components/monitorBox.ts
+++ b/src/components/monitorBox.ts
@@ -16,7 +16,7 @@ export class MonitorBox extends St1.BoxLayout {
   static metaInfo: GObject.MetaInfo<Record<string, never>, Record<string, never>, MonitorBoxSignals> = {
     GTypeName: 'MonitorBox',
     Signals: {
-      hide: {},
+      hide_window: {},
     },
   };
 
@@ -32,7 +32,7 @@ export class MonitorBox extends St1.BoxLayout {
     });
 
     this.connect('button-press-event', () => {
-      this.emit('hide');
+      this.emit('hide_window');
       return Clutter.EVENT_STOP;
     });
 

--- a/src/containers/panoWindow.ts
+++ b/src/containers/panoWindow.ts
@@ -118,7 +118,7 @@ export class PanoWindow extends St1.BoxLayout {
   }
 
   private setupMonitorBox() {
-    this.monitorBox.connect('hide', () => this.hide());
+    this.monitorBox.connect('hide_window', () => this.hide());
   }
 
   private setupSearchBox() {


### PR DESCRIPTION
# Pull Request Template

## Description

This pull request fixes this warning: `../../../gobject/gsignal.c:1746: signal "hide" already exists in the 'ClutterActor' class ancestry` (which, although displayed as a warning, is technically a critical error). To achieve this, I renamed the `hide` signal in `MonitorBox` to `hide1`. A better name would be nice, but I couldn't think of anything else.

This also changes the logger to use `console.debug` to follow [this guideline](https://gjs.guide/extensions/development/debugging.html#recommended-practices).

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] My commits follow the commit standards of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
