### PR TITLE
fix: disable paste on select before tracking

### DIFF
--- a/resources/po/ar.po
+++ b/resources/po/ar.po
@@ -31,7 +31,7 @@ msgstr "الوضع المخفي"
 msgid "Settings"
 msgstr "الإعدادات"
 
-#: src/components/linkPanoItem.ts:39
+#: src/components/linkPanoItem.ts:38
 msgid "No Description"
 msgstr ""
 

--- a/resources/po/bg.po
+++ b/resources/po/bg.po
@@ -31,7 +31,7 @@ msgstr "Режим \"инкогнито\""
 msgid "Settings"
 msgstr "Настройки"
 
-#: src/components/linkPanoItem.ts:39
+#: src/components/linkPanoItem.ts:38
 msgid "No Description"
 msgstr ""
 

--- a/resources/po/cs.po
+++ b/resources/po/cs.po
@@ -31,7 +31,7 @@ msgstr "Anonymní režim"
 msgid "Settings"
 msgstr "Nastavení"
 
-#: src/components/linkPanoItem.ts:39
+#: src/components/linkPanoItem.ts:38
 msgid "No Description"
 msgstr "Bez popisu"
 

--- a/resources/po/da.po
+++ b/resources/po/da.po
@@ -31,7 +31,7 @@ msgstr "Inkognitotilstand"
 msgid "Settings"
 msgstr "Indstillinger"
 
-#: src/components/linkPanoItem.ts:39
+#: src/components/linkPanoItem.ts:38
 msgid "No Description"
 msgstr ""
 

--- a/resources/po/de.po
+++ b/resources/po/de.po
@@ -1,113 +1,11 @@
 msgid ""
 msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 3.4.1\n"
-
-#: src/prefs/customization/commonStyleGroup.ts:72
-msgid "Active Item Border Color"
-msgstr "Randfarbe des aktiven Eintrags"
-
-#: src/prefs/general/openLinksInBrowser.ts:16
-msgid "Allow Pano to open links on your default browser"
-msgstr "Pano erlauben, Verweise im Standardbrowser zu öffnen"
-
-#: src/prefs/general/pasteOnSelect.ts:16
-msgid "Allow Pano to paste content on select"
-msgstr "Pano erlauben, Inhalte beim Auswählen einzufügen"
-
-#: src/prefs/general/playAudioOnCopy.ts:15
-msgid "Allow Pano to play an audio when copying new content"
-msgstr "Pano erlauben, beim Kopieren von Inhalten Audio abzuspielen"
-
-#: src/prefs/general/sendNotificationOnCopy.ts:17
-msgid "Allow Pano to send notification when copying new content"
-msgstr ""
-"Pano erlauben, beim Kopieren neuer Inhalte eine Benachrichtigung anzuzeigen"
-
-#: src/prefs/general/linkPreviews.ts:15
-msgid "Allow Pano to visit links on your clipboard to generate link previews"
-msgstr "Pano erlauben, Verweise aufzurufen, um Vorschauen zu erstellen"
-
-#: src/prefs/general/incognitoShortcutRow.ts:17
-msgid "Allows you to toggle incognito mode"
-msgstr "Erlaubt Ihnen, den Inkognito-Modus zu (de)aktivieren"
-
-#: src/prefs/general/shortcutRow.ts:17
-msgid "Allows you to toggle visibility of the clipboard manager"
-msgstr ""
-"Erlaubt Ihnen, die Zwischenablage-Verwaltung anzuzeigen oder zu verstecken"
-
-#: src/components/indicator/clearHistoryDialog.ts:36
-#: src/prefs/dangerZone/clearHistory.ts:26
-msgid "Are you sure you want to clear history?"
-msgstr "Sind Sie sicher, dass Sie die Chronik leeren möchten?"
-
-#: src/prefs/customization/codeItemStyle.ts:42
-#: src/prefs/customization/emojiItemStyle.ts:42
-#: src/prefs/customization/fileItemStyle.ts:42
-#: src/prefs/customization/imageItemStyle.ts:41
-#: src/prefs/customization/linkItemStyle.ts:42
-#: src/prefs/customization/textItemStyle.ts:42
-msgid "Body Background Color"
-msgstr "Hintergrundfarbe des Hauptteils"
-
-#: src/prefs/customization/codeItemStyle.ts:50
-#: src/prefs/customization/colorItemStyle.ts:61
-#: src/prefs/customization/fileItemStyle.ts:55
-#: src/prefs/customization/textItemStyle.ts:55
-msgid "Body Font"
-msgstr "Schriftart des Hauptteils"
-
-#: src/prefs/customization/fileItemStyle.ts:51
-#: src/prefs/customization/textItemStyle.ts:51
-msgid "Body Text Color"
-msgstr "Textfarbe des Hauptteils"
-
-#: src/prefs/customization/commonStyleGroup.ts:36
-msgid "Bottom"
-msgstr "Unten"
+"X-Generator: fill-pot-po/2.2.8\n"
 
 #: src/components/indicator/clearHistoryDialog.ts:23
 msgid "Cancel"
 msgstr "Abbrechen"
-
-#: src/prefs/customization/codeItemStyle.ts:15
-msgid "Change the style of the code item"
-msgstr "Stil des Code-Eintrags ändern"
-
-#: src/prefs/customization/colorItemStyle.ts:15
-msgid "Change the style of the color item"
-msgstr "Stil des Farb-Eintrags ändern"
-
-#: src/prefs/customization/emojiItemStyle.ts:15
-msgid "Change the style of the emoji item"
-msgstr "Stil des Emoji-Eintrags ändern"
-
-#: src/prefs/customization/fileItemStyle.ts:15
-msgid "Change the style of the file item"
-msgstr "Stil des Datei-Eintrags ändern"
-
-#: src/prefs/customization/imageItemStyle.ts:14
-msgid "Change the style of the image item"
-msgstr "Stil des Bild-Eintrags ändern"
-
-#: src/prefs/customization/linkItemStyle.ts:15
-msgid "Change the style of the link item"
-msgstr "Stil des Verweis-Eintrags ändern"
-
-#: src/prefs/customization/textItemStyle.ts:15
-msgid "Change the style of the text item"
-msgstr "Stil des Text-Eintrags ändern"
-
-#: src/prefs/customization/codeItemStyle.ts:55
-#: src/prefs/customization/textItemStyle.ts:60
-msgid "Character Length"
-msgstr "Zeichenlänge"
-
-#: src/prefs/general/dbLocation.ts:26
-msgid "Choose pano database location"
-msgstr "Ort der Pano-Datenbank auswählen"
 
 #: src/components/indicator/clearHistoryDialog.ts:30
 #: src/prefs/dangerZone/clearHistory.ts:20
@@ -120,101 +18,34 @@ msgstr "Leeren"
 msgid "Clear History"
 msgstr "Chronik leeren"
 
-#: src/prefs/dangerZone/clearHistory.ts:15
-msgid "Clears the clipboard database and cache"
-msgstr "Leert die Zwischenablage-Datenbank und den Cache"
+#: src/components/indicator/clearHistoryDialog.ts:36
+#: src/prefs/dangerZone/clearHistory.ts:26
+msgid "Are you sure you want to clear history?"
+msgstr "Sind Sie sicher, dass Sie die Chronik leeren möchten?"
 
-#: src/utils/panoItemType.ts:12
-msgid "Code"
-msgstr "Code"
+#: src/components/indicator/settingsMenu.ts:61
+msgid "Incognito Mode"
+msgstr "Inkognito-Modus"
 
-#: src/utils/panoItemFactory.ts:399
-msgid "Code Copied"
-msgstr "Code kopiert"
+#: src/components/indicator/settingsMenu.ts:101
+msgid "Settings"
+msgstr "Einstellungen"
+
+#: src/components/linkPanoItem.ts:38
+msgid "No Description"
+msgstr "Keine Beschreibung"
+
+#: src/components/searchBox.ts:68
+msgid "Type to search, Tab to cycle"
+msgstr "Tippen zum Suchen, Tab zum Wechseln"
+
+#: src/prefs/customization/codeItemStyle.ts:15
+msgid "Change the style of the code item"
+msgstr "Stil des Code-Eintrags ändern"
 
 #: src/prefs/customization/codeItemStyle.ts:15
 msgid "Code Item Style"
 msgstr "Stil des Code-Eintrags"
-
-#: src/utils/panoItemType.ts:13
-msgid "Color"
-msgstr "Farbe"
-
-#: src/utils/panoItemFactory.ts:429
-msgid "Color Copied"
-msgstr "Farbe kopiert"
-
-#: src/prefs/customization/colorItemStyle.ts:15
-msgid "Color Item Style"
-msgstr "Stil des Farb-Eintrags"
-
-#: src/prefs/customization/commonStyleGroup.ts:14
-msgid "Common"
-msgstr "Allgemein"
-
-#: src/prefs/customization/index.ts:13
-msgid "Customization"
-msgstr "Anpassung"
-
-#: src/prefs/dangerZone/index.ts:12
-msgid "Danger Zone"
-msgstr "Gefahrenbereich"
-
-#: src/prefs/general/dbLocation.ts:18
-msgid "Database Location"
-msgstr "Ort der Datenbank"
-
-#: src/prefs/customization/commonStyleGroup.ts:21
-msgid "Default Icons"
-msgstr "Vorgabe-Icons"
-
-#: src/utils/panoItemType.ts:9
-msgid "Emoji"
-msgstr "Emoji"
-
-#: src/utils/panoItemFactory.ts:401
-msgid "Emoji Copied"
-msgstr "Emoji kopiert"
-
-#: src/prefs/customization/emojiItemStyle.ts:15
-msgid "Emoji Item Style"
-msgstr "Stil des Emoji-Eintrags"
-
-#: src/prefs/customization/emojiItemStyle.ts:51
-msgid "Emoji Size"
-msgstr "Emoji-Größe"
-
-#: src/prefs/general/exclusionGroup.ts:24
-msgid "Excluded Apps"
-msgstr "Ausgeschlossene Apps"
-
-#: src/prefs/general/dbLocation.ts:79
-msgid "Failed to select directory"
-msgstr "Auswählen des Verzeichnisses fehlgeschlagen"
-
-#: src/utils/panoItemType.ts:10
-msgid "File"
-msgstr "Datei"
-
-#: src/utils/panoItemFactory.ts:436
-msgid "File %s"
-msgstr "Datei %s"
-
-#: src/prefs/customization/fileItemStyle.ts:15
-msgid "File Item Style"
-msgstr "Stil des Datei-Eintrags"
-
-#: src/prefs/general/index.ts:13
-msgid "General"
-msgstr "Allgemein"
-
-#: src/prefs/general/generalGroup.ts:25
-msgid "General Options"
-msgstr "Allgemeine Optionen"
-
-#: src/prefs/general/shortcutRow.ts:16
-msgid "Global Shortcut"
-msgstr "Globales Tastenkürzel"
 
 #: src/prefs/customization/codeItemStyle.ts:22
 #: src/prefs/customization/colorItemStyle.ts:22
@@ -226,6 +57,16 @@ msgstr "Globales Tastenkürzel"
 msgid "Header Background Color"
 msgstr "Hintergrundfarbe der Überschrift"
 
+#: src/prefs/customization/codeItemStyle.ts:23
+#: src/prefs/customization/colorItemStyle.ts:23
+#: src/prefs/customization/emojiItemStyle.ts:23
+#: src/prefs/customization/fileItemStyle.ts:23
+#: src/prefs/customization/imageItemStyle.ts:22
+#: src/prefs/customization/linkItemStyle.ts:23
+#: src/prefs/customization/textItemStyle.ts:23
+msgid "You can change the background color of the header"
+msgstr "Sie können die Hintergrundfarbe der Überschrift ändern"
+
 #: src/prefs/customization/codeItemStyle.ts:32
 #: src/prefs/customization/colorItemStyle.ts:32
 #: src/prefs/customization/emojiItemStyle.ts:32
@@ -236,57 +77,395 @@ msgstr "Hintergrundfarbe der Überschrift"
 msgid "Header Text Color"
 msgstr "Textfarbe der Überschrift"
 
-#: src/prefs/general/historyLength.ts:15
-msgid "History Length"
-msgstr "Länge der Chronik"
+#: src/prefs/customization/codeItemStyle.ts:33
+#: src/prefs/customization/colorItemStyle.ts:33
+#: src/prefs/customization/emojiItemStyle.ts:33
+#: src/prefs/customization/fileItemStyle.ts:33
+#: src/prefs/customization/imageItemStyle.ts:32
+#: src/prefs/customization/linkItemStyle.ts:33
+#: src/prefs/customization/textItemStyle.ts:33
+msgid "You can change the text color of the header"
+msgstr "Sie können die Textfarbe der Überschrift ändern"
 
-#: src/prefs/customization/commonStyleGroup.ts:80
-msgid "Hovered Item Border Color"
-msgstr "Randfarbe des fokussierten Eintrags"
+#: src/prefs/customization/codeItemStyle.ts:42
+#: src/prefs/customization/emojiItemStyle.ts:42
+#: src/prefs/customization/fileItemStyle.ts:42
+#: src/prefs/customization/imageItemStyle.ts:41
+#: src/prefs/customization/linkItemStyle.ts:42
+#: src/prefs/customization/textItemStyle.ts:42
+msgid "Body Background Color"
+msgstr "Hintergrundfarbe des Hauptteils"
+
+#: src/prefs/customization/codeItemStyle.ts:43
+#: src/prefs/customization/emojiItemStyle.ts:43
+#: src/prefs/customization/fileItemStyle.ts:43
+#: src/prefs/customization/imageItemStyle.ts:42
+#: src/prefs/customization/linkItemStyle.ts:43
+#: src/prefs/customization/textItemStyle.ts:43
+msgid "You can change the background color of the body"
+msgstr "Sie können die Hintergrundfarbe des Hauptteils ändern"
+
+#: src/prefs/customization/codeItemStyle.ts:50
+#: src/prefs/customization/colorItemStyle.ts:61
+#: src/prefs/customization/fileItemStyle.ts:55
+#: src/prefs/customization/textItemStyle.ts:55
+msgid "Body Font"
+msgstr "Schriftart des Hauptteils"
+
+#: src/prefs/customization/codeItemStyle.ts:50
+#: src/prefs/customization/fileItemStyle.ts:55
+#: src/prefs/customization/textItemStyle.ts:55
+msgid "You can change the font of the body"
+msgstr "Sie können die Schriftart des Hauptteils ändern"
+
+#: src/prefs/customization/codeItemStyle.ts:55
+#: src/prefs/customization/textItemStyle.ts:60
+msgid "Character Length"
+msgstr "Zeichenlänge"
+
+#: src/prefs/customization/codeItemStyle.ts:56
+#: src/prefs/customization/textItemStyle.ts:61
+msgid "You can change the character length of the visible text in the body"
+msgstr "Sie können die Zeichenlänge des sichtbaren Textes im Hauptteil ändern"
+
+#: src/prefs/customization/colorItemStyle.ts:15
+msgid "Change the style of the color item"
+msgstr "Stil des Farb-Eintrags ändern"
+
+#: src/prefs/customization/colorItemStyle.ts:15
+msgid "Color Item Style"
+msgstr "Stil des Farb-Eintrags"
+
+#: src/prefs/customization/colorItemStyle.ts:42
+#: src/prefs/customization/imageItemStyle.ts:51
+#: src/prefs/customization/linkItemStyle.ts:52
+msgid "Metadata Background Color"
+msgstr "Hintergrundfarbe für Metadaten"
+
+#: src/prefs/customization/colorItemStyle.ts:43
+#: src/prefs/customization/imageItemStyle.ts:52
+#: src/prefs/customization/linkItemStyle.ts:53
+msgid "You can change the background color of the metadata"
+msgstr "Sie können die Hintergrundfarbe der Metadaten ändern"
+
+#: src/prefs/customization/colorItemStyle.ts:52
+#: src/prefs/customization/imageItemStyle.ts:61
+msgid "Metadata Text Color"
+msgstr "Textfarbe für Metadaten"
+
+#: src/prefs/customization/colorItemStyle.ts:53
+#: src/prefs/customization/imageItemStyle.ts:62
+msgid "You can change the text color of the metadata"
+msgstr "Sie können die Textfarbe der Metadaten ändern"
+
+#: src/prefs/customization/colorItemStyle.ts:61
+#: src/prefs/customization/imageItemStyle.ts:70
+msgid "You can change the font of the metadata"
+msgstr "Sie können die Schriftart der Metadaten ändern"
+
+#: src/prefs/customization/commonStyleGroup.ts:14
+msgid "Common"
+msgstr "Allgemein"
 
 #: src/prefs/customization/commonStyleGroup.ts:20
 msgid "Icon Pack"
 msgstr "Symbolpaket"
 
-#: src/utils/panoItemType.ts:11
-msgid "Image"
-msgstr "Bild"
+#: src/prefs/customization/commonStyleGroup.ts:20
+msgid "You can change the icon pack"
+msgstr "Sie können das Symbolpaket ändern"
 
-#: src/utils/panoItemFactory.ts:392
-msgid "Image Copied"
-msgstr "Bild kopiert"
+#: src/prefs/customization/commonStyleGroup.ts:21
+msgid "Default Icons"
+msgstr "Vorgabe-Icons"
 
-#: src/prefs/customization/imageItemStyle.ts:14
-msgid "Image Item Style"
-msgstr "Stil des Bild-Eintrags"
-
-#: src/components/indicator/settingsMenu.ts:61
-msgid "Incognito Mode"
-msgstr "Inkognito-Modus"
-
-#: src/prefs/general/incognitoShortcutRow.ts:16
-msgid "Incognito Mode Shortcut"
-msgstr "Tastenkürzel des Inkognito-Modus"
-
-#: src/prefs/customization/commonStyleGroup.ts:50
-msgid "Incognito Window Background Color"
-msgstr "Hintergrundfarbe des Inkognito-Fensters"
-
-#: src/prefs/customization/commonStyleGroup.ts:68
-msgid "Item Date Font"
-msgstr "Schriftart des Eintragsdatums"
+#: src/prefs/customization/commonStyleGroup.ts:22
+msgid "Legacy Icons"
+msgstr "Veraltete Symbole"
 
 #: src/prefs/customization/commonStyleGroup.ts:27
 msgid "Item Size"
 msgstr "Eintragsgröße"
 
-#: src/prefs/customization/itemStyleGroup.ts:18
-msgid "Item Style"
-msgstr "Eintragsstil"
+#: src/prefs/customization/commonStyleGroup.ts:27
+msgid "You can change the item size"
+msgstr "Sie können die Objektgröße ändern"
+
+#: src/prefs/customization/commonStyleGroup.ts:32
+msgid "Window Position"
+msgstr "Fensterposition"
+
+#: src/prefs/customization/commonStyleGroup.ts:33
+msgid "You can change position of the Pano"
+msgstr "Sie können die Position von Pano ändern"
+
+#: src/prefs/customization/commonStyleGroup.ts:36
+msgid "Bottom"
+msgstr "Unten"
+
+#: src/prefs/customization/commonStyleGroup.ts:36
+msgid "Left"
+msgstr "Links"
+
+#: src/prefs/customization/commonStyleGroup.ts:36
+msgid "Right"
+msgstr "Rechts"
+
+#: src/prefs/customization/commonStyleGroup.ts:36
+msgid "Top"
+msgstr "Oben"
+
+#: src/prefs/customization/commonStyleGroup.ts:42
+msgid "Window Background Color"
+msgstr "Hintergrundfarbe des Fensters"
+
+#: src/prefs/customization/commonStyleGroup.ts:43
+msgid "You can change the window background color"
+msgstr "Sie können die Hintergrundfarbe des Fensters ändern"
+
+#: src/prefs/customization/commonStyleGroup.ts:50
+msgid "Incognito Window Background Color"
+msgstr "Hintergrundfarbe des Inkognito-Fensters"
+
+#: src/prefs/customization/commonStyleGroup.ts:51
+msgid "You can change the incognito window background color"
+msgstr "Sie können die Hintergrundfarbe des Inkognito-Fensters ändern"
+
+#: src/prefs/customization/commonStyleGroup.ts:58
+msgid "Search Bar Font"
+msgstr "Schriftart der Suchleiste"
+
+#: src/prefs/customization/commonStyleGroup.ts:59
+msgid "You can change the font of the search bar"
+msgstr "Sie können die Schriftart der Suchleiste ändern"
 
 #: src/prefs/customization/commonStyleGroup.ts:65
 msgid "Item Title Font"
 msgstr "Schriftart des Eintragtitels"
+
+#: src/prefs/customization/commonStyleGroup.ts:65
+msgid "You can change the font of the title"
+msgstr "Sie können die Schriftart des Objekttitels ändern"
+
+#: src/prefs/customization/commonStyleGroup.ts:68
+msgid "Item Date Font"
+msgstr "Schriftart des Eintragsdatums"
+
+#: src/prefs/customization/commonStyleGroup.ts:68
+msgid "You can change the font of the date"
+msgstr "Sie können die Schriftart des Datums ändern"
+
+#: src/prefs/customization/commonStyleGroup.ts:72
+msgid "Active Item Border Color"
+msgstr "Randfarbe des aktiven Eintrags"
+
+#: src/prefs/customization/commonStyleGroup.ts:73
+msgid "You can change the active item border color"
+msgstr "Sie können die Randfarbe des aktiven Eintrags ändern"
+
+#: src/prefs/customization/commonStyleGroup.ts:80
+msgid "Hovered Item Border Color"
+msgstr "Randfarbe des fokussierten Eintrags"
+
+#: src/prefs/customization/commonStyleGroup.ts:81
+msgid "You can change the hovered item border color"
+msgstr "Sie können die Randfarbe des fokussierten Eintrags ändern"
+
+#: src/prefs/customization/emojiItemStyle.ts:15
+msgid "Change the style of the emoji item"
+msgstr "Stil des Emoji-Eintrags ändern"
+
+#: src/prefs/customization/emojiItemStyle.ts:15
+msgid "Emoji Item Style"
+msgstr "Stil des Emoji-Eintrags"
+
+#: src/prefs/customization/emojiItemStyle.ts:51
+msgid "Emoji Size"
+msgstr "Emoji-Größe"
+
+#: src/prefs/customization/emojiItemStyle.ts:51
+msgid "You can change the emoji size"
+msgstr "Sie können die Emoji-Größe ändern"
+
+#: src/prefs/customization/fileItemStyle.ts:15
+msgid "Change the style of the file item"
+msgstr "Stil des Datei-Eintrags ändern"
+
+#: src/prefs/customization/fileItemStyle.ts:15
+msgid "File Item Style"
+msgstr "Stil des Datei-Eintrags"
+
+#: src/prefs/customization/fileItemStyle.ts:51
+#: src/prefs/customization/textItemStyle.ts:51
+msgid "Body Text Color"
+msgstr "Textfarbe des Hauptteils"
+
+#: src/prefs/customization/fileItemStyle.ts:51
+#: src/prefs/customization/textItemStyle.ts:51
+msgid "You can change the text color of the body"
+msgstr "Sie können die Textfarbe des Hauptteils ändern"
+
+#: src/prefs/customization/imageItemStyle.ts:14
+msgid "Change the style of the image item"
+msgstr "Stil des Bild-Eintrags ändern"
+
+#: src/prefs/customization/imageItemStyle.ts:14
+msgid "Image Item Style"
+msgstr "Stil des Bild-Eintrags"
+
+#: src/prefs/customization/imageItemStyle.ts:70
+msgid "Metadata Font"
+msgstr "Schriftart für Metadaten"
+
+#: src/prefs/customization/index.ts:13
+msgid "Customization"
+msgstr "Anpassung"
+
+#: src/prefs/customization/itemStyleGroup.ts:18
+msgid "Item Style"
+msgstr "Eintragsstil"
+
+#: src/prefs/customization/linkItemStyle.ts:15
+msgid "Change the style of the link item"
+msgstr "Stil des Verweis-Eintrags ändern"
+
+#: src/prefs/customization/linkItemStyle.ts:15
+msgid "Link Item Style"
+msgstr "Stil Verweis-Eintrag"
+
+#: src/prefs/customization/linkItemStyle.ts:62
+msgid "Metadata Title Color"
+msgstr "Titelfarbe für Metadaten"
+
+#: src/prefs/customization/linkItemStyle.ts:63
+msgid "You can change the title color of the metadata"
+msgstr "Sie können die Titelfarbe der Metadaten ändern"
+
+#: src/prefs/customization/linkItemStyle.ts:72
+msgid "Metadata Title Font"
+msgstr "Schriftart für Metadatentitel"
+
+#: src/prefs/customization/linkItemStyle.ts:73
+msgid "You can change the font of the metadata title"
+msgstr "Sie können die Schriftart des Metadatentitels ändern"
+
+#: src/prefs/customization/linkItemStyle.ts:82
+msgid "Metadata Description Color"
+msgstr "Farbe für Metadatenbeschreibung"
+
+#: src/prefs/customization/linkItemStyle.ts:83
+msgid "You can change the description color of the metadata"
+msgstr "Sie können die Beschreibungsfarbe der Metadaten ändern"
+
+#: src/prefs/customization/linkItemStyle.ts:92
+msgid "Metadata Description Font"
+msgstr "Schriftart für Metadatenbeschreibung"
+
+#: src/prefs/customization/linkItemStyle.ts:93
+msgid "You can change the font of the metadata description"
+msgstr "Sie können die Schriftart der Metadatenbeschreibung ändern"
+
+#: src/prefs/customization/linkItemStyle.ts:102
+msgid "Metadata Link Color"
+msgstr "Verweisfarbe für Metadaten"
+
+#: src/prefs/customization/linkItemStyle.ts:103
+msgid "You can change the link color of the metadata"
+msgstr "Sie können die Verweisfarbe der Metadaten ändern"
+
+#: src/prefs/customization/linkItemStyle.ts:112
+msgid "Metadata Link Font"
+msgstr "Schriftart für Metadatenverweise"
+
+#: src/prefs/customization/linkItemStyle.ts:113
+msgid "You can change the font of the metadata link"
+msgstr "Sie können die Schriftart von Metadatenlinks ändern"
+
+#: src/prefs/customization/textItemStyle.ts:15
+msgid "Change the style of the text item"
+msgstr "Stil des Text-Eintrags ändern"
+
+#: src/prefs/customization/textItemStyle.ts:15
+msgid "Text Item Style"
+msgstr "Stil des Text-Eintrags"
+
+#: src/prefs/dangerZone/clearHistory.ts:15
+msgid "Clears the clipboard database and cache"
+msgstr "Leert die Zwischenablage-Datenbank und den Cache"
+
+#: src/prefs/dangerZone/index.ts:12
+msgid "Danger Zone"
+msgstr "Gefahrenbereich"
+
+#: src/prefs/dangerZone/sessionOnlyMode.ts:15
+msgid "Session Only Mode"
+msgstr "Einzelsession-Modus"
+
+#: src/prefs/dangerZone/sessionOnlyMode.ts:16
+msgid "When enabled, Pano will clear all history on logout/restart/shutdown."
+msgstr "Wenn aktiviert, wird Pano beim Abmelden, Neu starten und Herunterfahren die Chronik leeren."
+
+#: src/prefs/general/dbLocation.ts:18
+msgid "Database Location"
+msgstr "Ort der Datenbank"
+
+#: src/prefs/general/dbLocation.ts:26
+msgid "Choose pano database location"
+msgstr "Ort der Pano-Datenbank auswählen"
+
+#: src/prefs/general/dbLocation.ts:79
+msgid "Failed to select directory"
+msgstr "Auswählen des Verzeichnisses fehlgeschlagen"
+
+#: src/prefs/general/exclusionGroup.ts:17
+msgid "Manage Exclusions"
+msgstr "Ausschlüsse verwalten"
+
+#: src/prefs/general/exclusionGroup.ts:24
+msgid "Excluded Apps"
+msgstr "Ausgeschlossene Apps"
+
+#: src/prefs/general/exclusionGroup.ts:25
+msgid "Pano will stop tracking if any window from the list is focussed"
+msgstr "Pano wird nichts verfolgen, wenn ein Fenster aus der Liste fokussiert ist"
+
+#: src/prefs/general/exclusionGroup.ts:54
+msgid "Window class name"
+msgstr "Klassenname des Fensters"
+
+#: src/prefs/general/generalGroup.ts:25
+msgid "General Options"
+msgstr "Allgemeine Optionen"
+
+#: src/prefs/general/historyLength.ts:15
+msgid "History Length"
+msgstr "Länge der Chronik"
+
+#: src/prefs/general/historyLength.ts:16
+msgid "You can limit your clipboard history length between 10 - 500"
+msgstr "Sie können die Zwischenablagenchronik auf ein Länge zwischen 10 und 500 limitieren"
+
+#: src/prefs/general/incognitoShortcutRow.ts:16
+msgid "Incognito Mode Shortcut"
+msgstr "Tastenkürzel des Inkognito-Modus"
+
+#: src/prefs/general/incognitoShortcutRow.ts:17
+msgid "Allows you to toggle incognito mode"
+msgstr "Erlaubt Ihnen, den Inkognito-Modus zu (de)aktivieren"
+
+#: src/prefs/general/incognitoShortcutRow.ts:23
+#: src/prefs/general/shortcutRow.ts:23
+msgid "Select a shortcut"
+msgstr "Ein Kürzel auswählen"
+
+#: src/prefs/general/incognitoShortcutRow.ts:36
+#: src/prefs/general/shortcutRow.ts:36
+msgid "New shortcut"
+msgstr "Neues Kürzel"
+
+#: src/prefs/general/index.ts:13
+msgid "General"
+msgstr "Allgemein"
 
 #: src/prefs/general/keepSearchEntryOnHide.ts:15
 msgid "Keep Search Entry"
@@ -296,127 +475,53 @@ msgstr "Such-Eintrag behalten"
 msgid "Keep search entry when Pano hides"
 msgstr "Such-Eintrag behalten, wenn Pano versteckt wird"
 
-#: src/prefs/customization/commonStyleGroup.ts:36
-msgid "Left"
-msgstr "Links"
-
-#: src/prefs/customization/commonStyleGroup.ts:22
-msgid "Legacy Icons"
-msgstr "Veraltete Symbole"
-
-#: src/utils/panoItemType.ts:7
-msgid "Link"
-msgstr "Verweis"
-
-#: src/utils/panoItemFactory.ts:409
-msgid "Link Copied"
-msgstr "Verweis kopiert"
-
-#: src/prefs/customization/linkItemStyle.ts:15
-msgid "Link Item Style"
-msgstr "Stil Verweis-Eintrag"
-
 #: src/prefs/general/linkPreviews.ts:14
 msgid "Link Previews"
 msgstr "Verweisvorschauen"
 
-#: src/prefs/general/exclusionGroup.ts:17
-msgid "Manage Exclusions"
-msgstr "Ausschlüsse verwalten"
-
-#: src/prefs/customization/colorItemStyle.ts:42
-#: src/prefs/customization/imageItemStyle.ts:51
-#: src/prefs/customization/linkItemStyle.ts:52
-msgid "Metadata Background Color"
-msgstr "Hintergrundfarbe für Metadaten"
-
-#: src/prefs/customization/linkItemStyle.ts:82
-msgid "Metadata Description Color"
-msgstr "Farbe für Metadatenbeschreibung"
-
-#: src/prefs/customization/linkItemStyle.ts:92
-msgid "Metadata Description Font"
-msgstr "Schriftart für Metadatenbeschreibung"
-
-#: src/prefs/customization/imageItemStyle.ts:70
-msgid "Metadata Font"
-msgstr "Schriftart für Metadaten"
-
-#: src/prefs/customization/linkItemStyle.ts:102
-msgid "Metadata Link Color"
-msgstr "Verweisfarbe für Metadaten"
-
-#: src/prefs/customization/linkItemStyle.ts:112
-msgid "Metadata Link Font"
-msgstr "Schriftart für Metadatenverweise"
-
-#: src/prefs/customization/colorItemStyle.ts:52
-#: src/prefs/customization/imageItemStyle.ts:61
-msgid "Metadata Text Color"
-msgstr "Textfarbe für Metadaten"
-
-#: src/prefs/customization/linkItemStyle.ts:62
-msgid "Metadata Title Color"
-msgstr "Titelfarbe für Metadaten"
-
-#: src/prefs/customization/linkItemStyle.ts:72
-msgid "Metadata Title Font"
-msgstr "Schriftart für Metadatentitel"
-
-#: src/prefs/general/incognitoShortcutRow.ts:36
-#: src/prefs/general/shortcutRow.ts:36
-msgid "New shortcut"
-msgstr "Neues Kürzel"
-
-#: src/components/linkPanoItem.ts:39
-msgid "No Description"
-msgstr "Keine Beschreibung"
+#: src/prefs/general/linkPreviews.ts:15
+msgid "Allow Pano to visit links on your clipboard to generate link previews"
+msgstr "Pano erlauben, Verweise aufzurufen, um Vorschauen zu erstellen"
 
 #: src/prefs/general/openLinksInBrowser.ts:15
 msgid "Open Links in Browser"
 msgstr "Verweise im Browser öffnen"
 
-#: src/utils/ui.ts:24
-msgid "Pano"
-msgstr "Pano"
-
-#: src/prefs/general/exclusionGroup.ts:25
-msgid "Pano will stop tracking if any window from the list is focussed"
-msgstr ""
-"Pano wird nichts verfolgen, wenn ein Fenster aus der Liste fokussiert ist"
+#: src/prefs/general/openLinksInBrowser.ts:16
+msgid "Allow Pano to open links on your default browser"
+msgstr "Pano erlauben, Verweise im Standardbrowser zu öffnen"
 
 #: src/prefs/general/pasteOnSelect.ts:15
 msgid "Paste on Select"
 msgstr "Bei Auswahl einfügen"
 
+#: src/prefs/general/pasteOnSelect.ts:16
+msgid "Allow Pano to paste content on select"
+msgstr "Pano erlauben, Inhalte beim Auswählen einzufügen"
+
 #: src/prefs/general/playAudioOnCopy.ts:14
 msgid "Play an Audio on Copy"
 msgstr "Beim Kopieren Audio abspielen"
 
-#: src/prefs/customization/commonStyleGroup.ts:36
-msgid "Right"
-msgstr "Rechts"
-
-#: src/prefs/customization/commonStyleGroup.ts:58
-msgid "Search Bar Font"
-msgstr "Schriftart der Suchleiste"
-
-#: src/prefs/general/incognitoShortcutRow.ts:23
-#: src/prefs/general/shortcutRow.ts:23
-msgid "Select a shortcut"
-msgstr "Ein Kürzel auswählen"
+#: src/prefs/general/playAudioOnCopy.ts:15
+msgid "Allow Pano to play an audio when copying new content"
+msgstr "Pano erlauben, beim Kopieren von Inhalten Audio abzuspielen"
 
 #: src/prefs/general/sendNotificationOnCopy.ts:16
 msgid "Send Notification on Copy"
 msgstr "Beim Kopieren eine Benachrichtigung senden"
 
-#: src/prefs/dangerZone/sessionOnlyMode.ts:15
-msgid "Session Only Mode"
-msgstr "Einzelsession-Modus"
+#: src/prefs/general/sendNotificationOnCopy.ts:17
+msgid "Allow Pano to send notification when copying new content"
+msgstr "Pano erlauben, beim Kopieren neuer Inhalte eine Benachrichtigung anzuzeigen"
 
-#: src/components/indicator/settingsMenu.ts:101
-msgid "Settings"
-msgstr "Einstellungen"
+#: src/prefs/general/shortcutRow.ts:16
+msgid "Global Shortcut"
+msgstr "Globales Tastenkürzel"
+
+#: src/prefs/general/shortcutRow.ts:17
+msgid "Allows you to toggle visibility of the clipboard manager"
+msgstr "Erlaubt Ihnen, die Zwischenablage-Verwaltung anzuzeigen oder zu verstecken"
 
 #: src/prefs/general/showIndicator.ts:15
 msgid "Show Indicator"
@@ -434,47 +539,13 @@ msgstr "Primärauswahl synchronisieren"
 msgid "Sync primary selection with clipboard selection"
 msgstr "Primäre Auswahl mit der Auswahl der Zwischenablage synchronisieren"
 
-#: src/utils/panoItemType.ts:8
-msgid "Text"
-msgstr "Text"
-
-#: src/utils/panoItemFactory.ts:397
-msgid "Text Copied"
-msgstr "Text kopiert"
-
-#: src/prefs/customization/textItemStyle.ts:15
-msgid "Text Item Style"
-msgstr "Stil des Text-Eintrags"
-
-#: src/utils/panoItemFactory.ts:437
-msgid "There are %s file(s)"
-msgstr "Es gibt %s Datei(en)"
-
-#: src/prefs/customization/commonStyleGroup.ts:36
-msgid "Top"
-msgstr "Oben"
-
-#: src/components/searchBox.ts:68
-msgid "Type to search, Tab to cycle"
-msgstr "Tippen zum Suchen, Tab zum Wechseln"
-
 #: src/prefs/general/watchExclusions.ts:14
 msgid "Watch Exclusions"
 msgstr "Ausschlüsse überwachen"
 
-#: src/prefs/dangerZone/sessionOnlyMode.ts:16
-msgid "When enabled, Pano will clear all history on logout/restart/shutdown."
-msgstr ""
-"Wenn aktiviert, wird Pano beim Abmelden, Neu starten und Herunterfahren die "
-"Chronik leeren."
-
 #: src/prefs/general/watchExclusions.ts:15
 msgid "When enabled, Pano will not track clipboard from excluded apps"
 msgstr "Wenn aktiviert, wird Pano die ausgeschlossenen Apps nicht verfolgen"
-
-#: src/utils/panoItemFactory.ts:393
-msgid "Width: %spx, Height: %spx, Size: %s"
-msgstr "Breite: %spx, Höhe: %spx, Größe: %s"
 
 #: src/prefs/general/wiggleIndicator.ts:15
 msgid "Wiggle Indicator"
@@ -484,149 +555,70 @@ msgstr "Wackelindikator"
 msgid "Wiggles the indicator on panel"
 msgstr "Lässt den Indikator auf dem Bedienfeld wackeln"
 
-#: src/prefs/customization/commonStyleGroup.ts:42
-msgid "Window Background Color"
-msgstr "Hintergrundfarbe des Fensters"
+#: src/utils/panoItemFactory.ts:392
+msgid "Image Copied"
+msgstr "Bild kopiert"
 
-#: src/prefs/general/exclusionGroup.ts:54
-msgid "Window class name"
-msgstr "Klassenname des Fensters"
+#: src/utils/panoItemFactory.ts:393
+msgid "Width: %spx, Height: %spx, Size: %s"
+msgstr "Breite: %spx, Höhe: %spx, Größe: %s"
 
-#: src/prefs/customization/commonStyleGroup.ts:32
-msgid "Window Position"
-msgstr "Fensterposition"
+#: src/utils/panoItemFactory.ts:397
+msgid "Text Copied"
+msgstr "Text kopiert"
 
-#: src/prefs/customization/commonStyleGroup.ts:33
-msgid "You can change position of the Pano"
-msgstr "Sie können die Position von Pano ändern"
+#: src/utils/panoItemFactory.ts:399
+msgid "Code Copied"
+msgstr "Code kopiert"
 
-#: src/prefs/customization/commonStyleGroup.ts:73
-msgid "You can change the active item border color"
-msgstr "Sie können die Randfarbe des aktiven Eintrags ändern"
+#: src/utils/panoItemFactory.ts:401
+msgid "Emoji Copied"
+msgstr "Emoji kopiert"
 
-#: src/prefs/customization/codeItemStyle.ts:43
-#: src/prefs/customization/emojiItemStyle.ts:43
-#: src/prefs/customization/fileItemStyle.ts:43
-#: src/prefs/customization/imageItemStyle.ts:42
-#: src/prefs/customization/linkItemStyle.ts:43
-#: src/prefs/customization/textItemStyle.ts:43
-msgid "You can change the background color of the body"
-msgstr "Sie können die Hintergrundfarbe des Hauptteils ändern"
+#: src/utils/panoItemFactory.ts:409
+msgid "Link Copied"
+msgstr "Verweis kopiert"
 
-#: src/prefs/customization/codeItemStyle.ts:23
-#: src/prefs/customization/colorItemStyle.ts:23
-#: src/prefs/customization/emojiItemStyle.ts:23
-#: src/prefs/customization/fileItemStyle.ts:23
-#: src/prefs/customization/imageItemStyle.ts:22
-#: src/prefs/customization/linkItemStyle.ts:23
-#: src/prefs/customization/textItemStyle.ts:23
-msgid "You can change the background color of the header"
-msgstr "Sie können die Hintergrundfarbe der Überschrift ändern"
+#: src/utils/panoItemFactory.ts:429
+msgid "Color Copied"
+msgstr "Farbe kopiert"
 
-#: src/prefs/customization/colorItemStyle.ts:43
-#: src/prefs/customization/imageItemStyle.ts:52
-#: src/prefs/customization/linkItemStyle.ts:53
-msgid "You can change the background color of the metadata"
-msgstr "Sie können die Hintergrundfarbe der Metadaten ändern"
+#: src/utils/panoItemFactory.ts:436
+msgid "File %s"
+msgstr "Datei %s"
 
-#: src/prefs/customization/codeItemStyle.ts:56
-#: src/prefs/customization/textItemStyle.ts:61
-msgid "You can change the character length of the visible text in the body"
-msgstr "Sie können die Zeichenlänge des sichtbaren Textes im Hauptteil ändern"
+#: src/utils/panoItemFactory.ts:437
+msgid "There are %s file(s)"
+msgstr "Es gibt %s Datei(en)"
 
-#: src/prefs/customization/linkItemStyle.ts:83
-msgid "You can change the description color of the metadata"
-msgstr "Sie können die Beschreibungsfarbe der Metadaten ändern"
+#: src/utils/panoItemType.ts:7
+msgid "Link"
+msgstr "Verweis"
 
-#: src/prefs/customization/emojiItemStyle.ts:51
-msgid "You can change the emoji size"
-msgstr "Sie können die Emoji-Größe ändern"
+#: src/utils/panoItemType.ts:8
+msgid "Text"
+msgstr "Text"
 
-#: src/prefs/customization/codeItemStyle.ts:50
-#: src/prefs/customization/fileItemStyle.ts:55
-#: src/prefs/customization/textItemStyle.ts:55
-msgid "You can change the font of the body"
-msgstr "Sie können die Schriftart des Hauptteils ändern"
+#: src/utils/panoItemType.ts:9
+msgid "Emoji"
+msgstr "Emoji"
 
-#: src/prefs/customization/commonStyleGroup.ts:68
-msgid "You can change the font of the date"
-msgstr "Sie können die Schriftart des Datums ändern"
+#: src/utils/panoItemType.ts:10
+msgid "File"
+msgstr "Datei"
 
-#: src/prefs/customization/colorItemStyle.ts:61
-#: src/prefs/customization/imageItemStyle.ts:70
-msgid "You can change the font of the metadata"
-msgstr "Sie können die Schriftart der Metadaten ändern"
+#: src/utils/panoItemType.ts:11
+msgid "Image"
+msgstr "Bild"
 
-#: src/prefs/customization/linkItemStyle.ts:93
-msgid "You can change the font of the metadata description"
-msgstr "Sie können die Schriftart der Metadatenbeschreibung ändern"
+#: src/utils/panoItemType.ts:12
+msgid "Code"
+msgstr "Code"
 
-#: src/prefs/customization/linkItemStyle.ts:113
-msgid "You can change the font of the metadata link"
-msgstr "Sie können die Schriftart von Metadatenlinks ändern"
+#: src/utils/panoItemType.ts:13
+msgid "Color"
+msgstr "Farbe"
 
-#: src/prefs/customization/linkItemStyle.ts:73
-msgid "You can change the font of the metadata title"
-msgstr "Sie können die Schriftart des Metadatentitels ändern"
-
-#: src/prefs/customization/commonStyleGroup.ts:59
-msgid "You can change the font of the search bar"
-msgstr "Sie können die Schriftart der Suchleiste ändern"
-
-#: src/prefs/customization/commonStyleGroup.ts:65
-msgid "You can change the font of the title"
-msgstr "Sie können die Schriftart des Objekttitels ändern"
-
-#: src/prefs/customization/commonStyleGroup.ts:81
-msgid "You can change the hovered item border color"
-msgstr "Sie können die Randfarbe des fokussierten Eintrags ändern"
-
-#: src/prefs/customization/commonStyleGroup.ts:20
-msgid "You can change the icon pack"
-msgstr "Sie können das Symbolpaket ändern"
-
-#: src/prefs/customization/commonStyleGroup.ts:51
-msgid "You can change the incognito window background color"
-msgstr "Sie können die Hintergrundfarbe des Inkognito-Fensters ändern"
-
-#: src/prefs/customization/commonStyleGroup.ts:27
-msgid "You can change the item size"
-msgstr "Sie können die Objektgröße ändern"
-
-#: src/prefs/customization/linkItemStyle.ts:103
-msgid "You can change the link color of the metadata"
-msgstr "Sie können die Verweisfarbe der Metadaten ändern"
-
-#: src/prefs/customization/fileItemStyle.ts:51
-#: src/prefs/customization/textItemStyle.ts:51
-msgid "You can change the text color of the body"
-msgstr "Sie können die Textfarbe des Hauptteils ändern"
-
-#: src/prefs/customization/codeItemStyle.ts:33
-#: src/prefs/customization/colorItemStyle.ts:33
-#: src/prefs/customization/emojiItemStyle.ts:33
-#: src/prefs/customization/fileItemStyle.ts:33
-#: src/prefs/customization/imageItemStyle.ts:32
-#: src/prefs/customization/linkItemStyle.ts:33
-#: src/prefs/customization/textItemStyle.ts:33
-msgid "You can change the text color of the header"
-msgstr "Sie können die Textfarbe der Überschrift ändern"
-
-#: src/prefs/customization/colorItemStyle.ts:53
-#: src/prefs/customization/imageItemStyle.ts:62
-msgid "You can change the text color of the metadata"
-msgstr "Sie können die Textfarbe der Metadaten ändern"
-
-#: src/prefs/customization/linkItemStyle.ts:63
-msgid "You can change the title color of the metadata"
-msgstr "Sie können die Titelfarbe der Metadaten ändern"
-
-#: src/prefs/customization/commonStyleGroup.ts:43
-msgid "You can change the window background color"
-msgstr "Sie können die Hintergrundfarbe des Fensters ändern"
-
-#: src/prefs/general/historyLength.ts:16
-msgid "You can limit your clipboard history length between 10 - 500"
-msgstr ""
-"Sie können die Zwischenablagenchronik auf ein Länge zwischen 10 und 500 "
-"limitieren"
+#: src/utils/ui.ts:24
+msgid "Pano"
+msgstr "Pano"

--- a/resources/po/el.po
+++ b/resources/po/el.po
@@ -31,7 +31,7 @@ msgstr "Ανώνυμης"
 msgid "Settings"
 msgstr "Ρυθμίσεις"
 
-#: src/components/linkPanoItem.ts:39
+#: src/components/linkPanoItem.ts:38
 msgid "No Description"
 msgstr ""
 

--- a/resources/po/en.po
+++ b/resources/po/en.po
@@ -31,7 +31,7 @@ msgstr "Incognito Mode"
 msgid "Settings"
 msgstr "Settings"
 
-#: src/components/linkPanoItem.ts:39
+#: src/components/linkPanoItem.ts:38
 msgid "No Description"
 msgstr ""
 

--- a/resources/po/es.po
+++ b/resources/po/es.po
@@ -31,7 +31,7 @@ msgstr "Modo incógnito"
 msgid "Settings"
 msgstr "Configuración"
 
-#: src/components/linkPanoItem.ts:39
+#: src/components/linkPanoItem.ts:38
 msgid "No Description"
 msgstr "Sin descripción"
 

--- a/resources/po/et.po
+++ b/resources/po/et.po
@@ -31,7 +31,7 @@ msgstr "Inkognito režiim"
 msgid "Settings"
 msgstr "Seaded"
 
-#: src/components/linkPanoItem.ts:39
+#: src/components/linkPanoItem.ts:38
 msgid "No Description"
 msgstr ""
 

--- a/resources/po/fi.po
+++ b/resources/po/fi.po
@@ -31,7 +31,7 @@ msgstr "Incognito-tila"
 msgid "Settings"
 msgstr "Asetukset"
 
-#: src/components/linkPanoItem.ts:39
+#: src/components/linkPanoItem.ts:38
 msgid "No Description"
 msgstr ""
 

--- a/resources/po/fr.po
+++ b/resources/po/fr.po
@@ -31,7 +31,7 @@ msgstr "Mode incognito"
 msgid "Settings"
 msgstr "Paramètres"
 
-#: src/components/linkPanoItem.ts:39
+#: src/components/linkPanoItem.ts:38
 msgid "No Description"
 msgstr "Aucune description"
 

--- a/resources/po/he.po
+++ b/resources/po/he.po
@@ -31,7 +31,7 @@ msgstr "מצב גלישה בסתר"
 msgid "Settings"
 msgstr "הגדרות"
 
-#: src/components/linkPanoItem.ts:39
+#: src/components/linkPanoItem.ts:38
 msgid "No Description"
 msgstr ""
 

--- a/resources/po/hr.po
+++ b/resources/po/hr.po
@@ -31,7 +31,7 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: src/components/linkPanoItem.ts:39
+#: src/components/linkPanoItem.ts:38
 msgid "No Description"
 msgstr ""
 

--- a/resources/po/hu.po
+++ b/resources/po/hu.po
@@ -31,7 +31,7 @@ msgstr "Inkognitómód"
 msgid "Settings"
 msgstr "Beállítások"
 
-#: src/components/linkPanoItem.ts:39
+#: src/components/linkPanoItem.ts:38
 msgid "No Description"
 msgstr ""
 

--- a/resources/po/is.po
+++ b/resources/po/is.po
@@ -31,7 +31,7 @@ msgstr "Huliðsstilling"
 msgid "Settings"
 msgstr "Stillingar"
 
-#: src/components/linkPanoItem.ts:39
+#: src/components/linkPanoItem.ts:38
 msgid "No Description"
 msgstr ""
 

--- a/resources/po/it.po
+++ b/resources/po/it.po
@@ -31,7 +31,7 @@ msgstr "Modalità di navigazione in incognito"
 msgid "Settings"
 msgstr "Impostazioni"
 
-#: src/components/linkPanoItem.ts:39
+#: src/components/linkPanoItem.ts:38
 msgid "No Description"
 msgstr "Nessuna descrizione"
 

--- a/resources/po/ja.po
+++ b/resources/po/ja.po
@@ -31,7 +31,7 @@ msgstr "シークレットモード"
 msgid "Settings"
 msgstr "設定"
 
-#: src/components/linkPanoItem.ts:39
+#: src/components/linkPanoItem.ts:38
 msgid "No Description"
 msgstr ""
 

--- a/resources/po/ko.po
+++ b/resources/po/ko.po
@@ -31,7 +31,7 @@ msgstr "시크릿 모드"
 msgid "Settings"
 msgstr "설정"
 
-#: src/components/linkPanoItem.ts:39
+#: src/components/linkPanoItem.ts:38
 msgid "No Description"
 msgstr ""
 

--- a/resources/po/nl.po
+++ b/resources/po/nl.po
@@ -31,7 +31,7 @@ msgstr "Incognitomodus"
 msgid "Settings"
 msgstr "Voorkeuren"
 
-#: src/components/linkPanoItem.ts:39
+#: src/components/linkPanoItem.ts:38
 msgid "No Description"
 msgstr ""
 

--- a/resources/po/no.po
+++ b/resources/po/no.po
@@ -31,7 +31,7 @@ msgstr "Inkognitomodus"
 msgid "Settings"
 msgstr "Innstillinger"
 
-#: src/components/linkPanoItem.ts:39
+#: src/components/linkPanoItem.ts:38
 msgid "No Description"
 msgstr ""
 

--- a/resources/po/oc.po
+++ b/resources/po/oc.po
@@ -31,7 +31,7 @@ msgstr "Mòde incognito"
 msgid "Settings"
 msgstr "Paramètres"
 
-#: src/components/linkPanoItem.ts:39
+#: src/components/linkPanoItem.ts:38
 msgid "No Description"
 msgstr ""
 

--- a/resources/po/pano@elhan.io.pot
+++ b/resources/po/pano@elhan.io.pot
@@ -364,7 +364,7 @@ msgstr ""
 msgid "New shortcut"
 msgstr ""
 
-#: src/components/linkPanoItem.ts:39
+#: src/components/linkPanoItem.ts:38
 msgid "No Description"
 msgstr ""
 

--- a/resources/po/pl.po
+++ b/resources/po/pl.po
@@ -31,7 +31,7 @@ msgstr "Tryb Incognito"
 msgid "Settings"
 msgstr "Ustawienia"
 
-#: src/components/linkPanoItem.ts:39
+#: src/components/linkPanoItem.ts:38
 msgid "No Description"
 msgstr ""
 

--- a/resources/po/pt.po
+++ b/resources/po/pt.po
@@ -31,7 +31,7 @@ msgstr "Modo de navegação anónima"
 msgid "Settings"
 msgstr "Configurações"
 
-#: src/components/linkPanoItem.ts:39
+#: src/components/linkPanoItem.ts:38
 msgid "No Description"
 msgstr ""
 

--- a/resources/po/pt_BR.po
+++ b/resources/po/pt_BR.po
@@ -31,7 +31,7 @@ msgstr "Modo anônimo"
 msgid "Settings"
 msgstr "Configurações"
 
-#: src/components/linkPanoItem.ts:39
+#: src/components/linkPanoItem.ts:38
 msgid "No Description"
 msgstr "Sem descrição"
 

--- a/resources/po/ro.po
+++ b/resources/po/ro.po
@@ -31,7 +31,7 @@ msgstr "Modul incognito"
 msgid "Settings"
 msgstr "Setări"
 
-#: src/components/linkPanoItem.ts:39
+#: src/components/linkPanoItem.ts:38
 msgid "No Description"
 msgstr ""
 

--- a/resources/po/ru.po
+++ b/resources/po/ru.po
@@ -31,7 +31,7 @@ msgstr "Режим инкогнито"
 msgid "Settings"
 msgstr "Настройки"
 
-#: src/components/linkPanoItem.ts:39
+#: src/components/linkPanoItem.ts:38
 msgid "No Description"
 msgstr "Без описания"
 

--- a/resources/po/sk.po
+++ b/resources/po/sk.po
@@ -31,7 +31,7 @@ msgstr "Režim inkognito"
 msgid "Settings"
 msgstr "Nastavenia"
 
-#: src/components/linkPanoItem.ts:39
+#: src/components/linkPanoItem.ts:38
 msgid "No Description"
 msgstr ""
 

--- a/resources/po/sv.po
+++ b/resources/po/sv.po
@@ -31,7 +31,7 @@ msgstr "Inkognitoläge"
 msgid "Settings"
 msgstr "Inställningar"
 
-#: src/components/linkPanoItem.ts:39
+#: src/components/linkPanoItem.ts:38
 msgid "No Description"
 msgstr ""
 

--- a/resources/po/tr.po
+++ b/resources/po/tr.po
@@ -31,7 +31,7 @@ msgstr "Gizli Mod"
 msgid "Settings"
 msgstr "Ayarlar"
 
-#: src/components/linkPanoItem.ts:39
+#: src/components/linkPanoItem.ts:38
 msgid "No Description"
 msgstr ""
 

--- a/resources/po/uk.po
+++ b/resources/po/uk.po
@@ -31,7 +31,7 @@ msgstr "Режим анонімного перегляду"
 msgid "Settings"
 msgstr "Параметри"
 
-#: src/components/linkPanoItem.ts:39
+#: src/components/linkPanoItem.ts:38
 msgid "No Description"
 msgstr ""
 

--- a/resources/po/vi.po
+++ b/resources/po/vi.po
@@ -31,7 +31,7 @@ msgstr "Chế Độ Ẩn Danh"
 msgid "Settings"
 msgstr "Cài Đặt"
 
-#: src/components/linkPanoItem.ts:39
+#: src/components/linkPanoItem.ts:38
 msgid "No Description"
 msgstr ""
 

--- a/resources/po/zh_CN.po
+++ b/resources/po/zh_CN.po
@@ -31,7 +31,7 @@ msgstr "隐身模式"
 msgid "Settings"
 msgstr "设置"
 
-#: src/components/linkPanoItem.ts:39
+#: src/components/linkPanoItem.ts:38
 msgid "No Description"
 msgstr "无详情"
 

--- a/resources/po/zh_TW.po
+++ b/resources/po/zh_TW.po
@@ -31,7 +31,7 @@ msgstr "無痕模式"
 msgid "Settings"
 msgstr "設定"
 
-#: src/components/linkPanoItem.ts:39
+#: src/components/linkPanoItem.ts:38
 msgid "No Description"
 msgstr "無說明"
 

--- a/src/components/panoItem.ts
+++ b/src/components/panoItem.ts
@@ -86,7 +86,7 @@ export class PanoItem extends St1.BoxLayout {
         return;
       }
 
-      if (this.settings.get_boolean('paste-on-select')) {
+      if (this.settings.get_boolean('paste-on-select') && this.clipboardManager.isTracking) {
         // See https://github.com/SUPERCILEX/gnome-clipboard-history/blob/master/extension.js#L606
         this.timeoutId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 250, () => {
           getVirtualKeyboard().notify_keyval(


### PR DESCRIPTION

# Pull Request Template

## Description

We should only enable paste-on-select when the user selects directly, and determine whether to enter an interactive state by check `clipboardManager.isTracking`

Fixes #232 #244

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] My commits follow the commit standards of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
