### PR TITLE
Fix Backslash Error

### DIFF
--- a/src/utils/db.ts
+++ b/src/utils/db.ts
@@ -1,6 +1,6 @@
 import Gda5 from '@girs/gda-5.0';
 import type { ExtensionBase } from '@girs/gnome-shell/dist/extensions/sharedInternals';
-import { add_expr_value } from '@pano/utils/compatibility';
+import { add_expr_value, type DataModelIter, type SqlBuilder } from '@pano/utils/compatibility';
 import { getDbPath, logger } from '@pano/utils/shell';
 
 const debug = logger('database');
@@ -214,20 +214,20 @@ class Database {
 
     const builder = new Gda5.SqlBuilder({
       stmt_type: Gda5.SqlStatementType.INSERT,
-    });
+    }) as SqlBuilder<DBItem>;
 
     builder.set_table('clipboard');
     //Note: casting required, since this is a gjs convention, that you don't have to pass a  GObject.Value, this is needed for teh C API, but GJS constructs it on the fly
-    builder.add_field_value_as_gvalue('itemType', dbItem.itemType as any);
-    builder.add_field_value_as_gvalue('content', dbItem.content as any);
-    builder.add_field_value_as_gvalue('copyDate', dbItem.copyDate.toISOString() as any);
-    builder.add_field_value_as_gvalue('isFavorite', +dbItem.isFavorite as any);
-    builder.add_field_value_as_gvalue('matchValue', dbItem.matchValue as any);
+    builder.add_field_value_as_gvalue('itemType', dbItem.itemType);
+    builder.add_field_value_as_gvalue('content', dbItem.content);
+    builder.add_field_value_as_gvalue('copyDate', dbItem.copyDate.toISOString());
+    builder.add_field_value_as_gvalue('isFavorite', +dbItem.isFavorite);
+    builder.add_field_value_as_gvalue('matchValue', dbItem.matchValue);
     if (dbItem.searchValue) {
-      builder.add_field_value_as_gvalue('searchValue', dbItem.searchValue as any);
+      builder.add_field_value_as_gvalue('searchValue', dbItem.searchValue);
     }
     if (dbItem.metaData) {
-      builder.add_field_value_as_gvalue('metaData', dbItem.metaData as any);
+      builder.add_field_value_as_gvalue('metaData', dbItem.metaData);
     }
     const [_, row] = this.connection.statement_execute_non_select(builder.get_statement(), null);
     const id = row?.get_nth_holder(0).get_value() as any as number;
@@ -254,20 +254,20 @@ class Database {
 
     const builder = new Gda5.SqlBuilder({
       stmt_type: Gda5.SqlStatementType.UPDATE,
-    });
+    }) as SqlBuilder<DBItem>;
 
     builder.set_table('clipboard');
     //Note: casting required, since this is a gjs convention, that you don't have to pass a  GObject.Value, this is needed for teh C API, but GJS constructs it on the fly
-    builder.add_field_value_as_gvalue('itemType', dbItem.itemType as any);
-    builder.add_field_value_as_gvalue('content', dbItem.content as any);
-    builder.add_field_value_as_gvalue('copyDate', dbItem.copyDate.toISOString() as any);
-    builder.add_field_value_as_gvalue('isFavorite', +dbItem.isFavorite as any);
-    builder.add_field_value_as_gvalue('matchValue', dbItem.matchValue as any);
+    builder.add_field_value_as_gvalue('itemType', dbItem.itemType);
+    builder.add_field_value_as_gvalue('content', dbItem.content);
+    builder.add_field_value_as_gvalue('copyDate', dbItem.copyDate.toISOString());
+    builder.add_field_value_as_gvalue('isFavorite', +dbItem.isFavorite);
+    builder.add_field_value_as_gvalue('matchValue', dbItem.matchValue);
     if (dbItem.searchValue) {
-      builder.add_field_value_as_gvalue('searchValue', dbItem.searchValue as any);
+      builder.add_field_value_as_gvalue('searchValue', dbItem.searchValue);
     }
     if (dbItem.metaData) {
-      builder.add_field_value_as_gvalue('metaData', dbItem.metaData as any);
+      builder.add_field_value_as_gvalue('metaData', dbItem.metaData);
     }
     builder.set_where(
       builder.add_cond(
@@ -313,31 +313,31 @@ class Database {
 
     const dm = this.connection.statement_execute_select(clipboardQuery.statement, null);
 
-    const iter = dm.create_iter();
+    const iter = dm.create_iter() as DataModelIter<DBItem>;
     const itemList: DBItem[] = [];
 
     while (iter.move_next()) {
       //Note: casting required, since this is a gjs convention, that any GObject.Value is just the value (e.g. string, number etc.) this types are from C, so there is no dynamic return value so they have to use GObject.Value
-      const id = iter.get_value_for_field('id') as any as number;
-      const itemType = iter.get_value_for_field('itemType') as any as ItemType;
-      const content = iter.get_value_for_field('content') as any as string;
-      const content_unescaped = Gda5.default_unescape_string(content) ?? content;
-      const copyDate = iter.get_value_for_field('copyDate') as any as string;
-      const isFavorite = iter.get_value_for_field('isFavorite') as any as number;
-      const matchValue = iter.get_value_for_field('matchValue') as any as string;
-      const matchValue_unescaped = Gda5.default_unescape_string(matchValue) ?? matchValue;
-      const searchValue = iter.get_value_for_field('searchValue') as any as string;
-      const searchValue_unescaped = Gda5.default_unescape_string(searchValue) ?? searchValue;
-      const metaData = iter.get_value_for_field('metaData') as any as string;
+      const id = iter.get_value_for_field('id');
+      const itemType = iter.get_value_for_field('itemType');
+      const content = iter.get_value_for_field('content');
+      const contentUnescaped = Gda5.default_unescape_string(content) ?? content;
+      const copyDate = iter.get_value_for_field('copyDate');
+      const isFavorite = iter.get_value_for_field('isFavorite');
+      const matchValue = iter.get_value_for_field('matchValue');
+      const matchValueUnescaped = Gda5.default_unescape_string(matchValue) ?? matchValue;
+      const searchValue = iter.get_value_for_field('searchValue');
+      const searchValueUnescaped = searchValue ? Gda5.default_unescape_string(searchValue) ?? searchValue : undefined;
+      const metaData = iter.get_value_for_field('metaData');
 
       itemList.push({
         id,
         itemType,
-        content: content_unescaped,
+        content: contentUnescaped,
         copyDate: new Date(copyDate),
         isFavorite: !!isFavorite,
-        matchValue: matchValue_unescaped,
-        searchValue: searchValue_unescaped,
+        matchValue: matchValueUnescaped,
+        searchValue: searchValueUnescaped,
         metaData,
       });
     }

--- a/src/utils/db.ts
+++ b/src/utils/db.ts
@@ -321,6 +321,7 @@ class Database {
       const id = iter.get_value_for_field('id') as any as number;
       const itemType = iter.get_value_for_field('itemType') as any as ItemType;
       const content = iter.get_value_for_field('content') as any as string;
+      const content_unescaped = Gda5.default_unescape_string(content) ?? content;
       const copyDate = iter.get_value_for_field('copyDate') as any as string;
       const isFavorite = iter.get_value_for_field('isFavorite') as any as number;
       const matchValue = iter.get_value_for_field('matchValue') as any as string;
@@ -330,7 +331,7 @@ class Database {
       itemList.push({
         id,
         itemType,
-        content,
+        content: content_unescaped,
         copyDate: new Date(copyDate),
         isFavorite: !!isFavorite,
         matchValue,

--- a/src/utils/db.ts
+++ b/src/utils/db.ts
@@ -325,7 +325,9 @@ class Database {
       const copyDate = iter.get_value_for_field('copyDate') as any as string;
       const isFavorite = iter.get_value_for_field('isFavorite') as any as number;
       const matchValue = iter.get_value_for_field('matchValue') as any as string;
+      const matchValue_unescaped = Gda5.default_unescape_string(matchValue) ?? matchValue;
       const searchValue = iter.get_value_for_field('searchValue') as any as string;
+      const searchValue_unescaped = Gda5.default_unescape_string(searchValue) ?? searchValue;
       const metaData = iter.get_value_for_field('metaData') as any as string;
 
       itemList.push({
@@ -334,8 +336,8 @@ class Database {
         content: content_unescaped,
         copyDate: new Date(copyDate),
         isFavorite: !!isFavorite,
-        matchValue,
-        searchValue,
+        matchValue: matchValue_unescaped,
+        searchValue: searchValue_unescaped,
         metaData,
       });
     }


### PR DESCRIPTION
# Fix Backslash Error

## Description

libgda escapes the string on inserting it into the db. You can't change that behavior (as far as my research goes) So the easiest method to fix this, is to unescape the string on retrieval. This could escape a few things too many, but my testing resulted in no errors and the issues fixed. This could potentially also occur in other fields, not just "content", but I see no possibility to add arbitrary data in any other field and there is no escape character in the hard-coded option / choices of the other strings, or the serialized date etc.

I tested it locally, but it would be great if it would be tested by another one too, I will daily drive this for now and if I discover issues, (like swallowed characters due to unescaping) I will report it, but I think it's safe to use, since it didn't yield any errors from some manual tests with `\` heavy files (latex files).

TODO:
- [x] add other fileds too ("searchValue" and "matchValue") thanks to @SanderTuit (https://github.com/Totto16/gnome-shell-pano/pull/3)
- [x] test other types of content too (image, emoji, color, etc.) and see if they need unescaping or not (https://github.com/oae/gnome-shell-pano/issues/196#issuecomment-2020859270)

Unescaping may fail, since there might be some wrong escape sequences in the string, so if the unescaping fails, we fallback to the escaped string, even if this should never fail, since it was escaped by libgda beforehand.


Fixes #196
Fixes #107

P.S: If this is merged, I also will file a PR to the legacy branch, to fix it in the Gnome < 45 too.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] My commits follow the commit standards of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
