### PR TITLE
[Bug fix]: Correctly handle right click on Indicator

### DIFF
--- a/src/components/indicator/settingsMenu.ts
+++ b/src/components/indicator/settingsMenu.ts
@@ -120,13 +120,16 @@ export class SettingsMenu extends PanelMenuButton {
   }
 
   override vfunc_event(event: Clutter.Event) {
-    if (
-      this.menu &&
-      event.type() === Clutter.EventType.BUTTON_PRESS &&
-      [Clutter.BUTTON_PRIMARY, Clutter.BUTTON_MIDDLE].includes(event.get_button())
-    ) {
-      this.onToggle();
+    if (event.type() === Clutter.EventType.BUTTON_PRESS) {
+      if ([Clutter.BUTTON_PRIMARY, Clutter.BUTTON_MIDDLE].includes(event.get_button())) {
+        this.onToggle();
+        return Clutter.EVENT_STOP;
+      } else if (this.menu && event.get_button() === Clutter.BUTTON_SECONDARY) {
+        this.menu.toggle();
+        return Clutter.EVENT_STOP;
+      }
     }
+
     return super.vfunc_event(event);
   }
 


### PR DESCRIPTION
# Pull Request Template

## Description

This was really straight forward fix, just handle the right click correctly and don't propagate the event, if its handled, also don't call the super class handler, since that might to other things, that are not intentional (that was the source of the bug, since the super event handler toggles the class on clicks)

Tested locally and it now works as intended 😄 

Fixes #283 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] My commits follow the commit standards of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
