### PR TITLE
ci: add option for the ci to check locales

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Validate Formatting
         run: yarn run prettier:check
 
+      - name: Validate Locale
+        run: yarn run check:locale
+
       - name: Lint Extension
         run: yarn run lint
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "yarn run build:ts && yarn run gen:locale && yarn run build:extension",
     "gen:locale": "yarn run ts-node scripts/generateLocale.ts",
+    "check:locale": "yarn run ts-node scripts/generateLocale.ts --dry-run",
     "build:ts": "yarn run clean:ts && rollup -c --failAfterWarnings && sed -i '/setTimeout/d' dist/thirdparty/prismjs.js && sed -i 's/var\\ /let\\ /g' dist/extension.js dist/prefs.js",
     "clean:ts": "rm -rf ./dist",
     "build:extension": "yarn run build:schema",


### PR DESCRIPTION
# Pull Request Template

## Description

add support for a "dry-run" to "generateLocale.ts" , so that locales get checked in the CI

This helps in the case of locale updates, as the CI catches such things as in [#305](https://github.com/oae/gnome-shell-pano/pull/305/files#diff-7a3c14c7d808418b86f88925087f83e6e07e7358472e8916b77393ccdaef48aeR3-R12)

This was done in a quick fashion and can certainly be improved, I didn't use a cli parser, since this just adds one simple optional option.

Any suggestions for improvements or arguments against this are welcome. ❤️ 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
## Checklist

- [x] My code follows the style guidelines of this project
- [x] My commits follow the commit standards of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
