### PR TITLE
fix: Restore clipboard tracking after clear history

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -141,6 +141,7 @@ export default class PanoExtension extends Extension {
   private async clearHistory() {
     this.stop();
     await deleteAppDirs(this);
+    this.setupResources();
     this.start();
   }
 


### PR DESCRIPTION
## Description

Debugging the scenario of this issue (trying to copy anything after clearing the history) I would see the output "connection is not opened", which is emitted from the guard clauses in `db.ts`. It seems the `clearHistory` function deletes the extension data but doesn't recreate its files or setup the db connection again.

My simplistic solution was calling `setupResources`, just like the extension startup does. I don't know if is the best approach... but it fixed the issue for me.

Closes #318 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] My code follows the style guidelines of this project
- [X] My commits follow the commit standards of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any misspellings
