### PR TITLE
chore: add release CI, to upload the archive

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Release CI
+
+on:
+  release:
+    types: published
+
+env:
+  node-version: 22.x
+
+jobs:
+  release:
+    name: Release CI
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ env.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.node-version }}
+
+      - name: Install dependencies
+        run: yarn install -D
+
+      - name: Validate Formatting
+        run: yarn run prettier:check
+
+      - name: Validate Locale
+        run: yarn run check:locale
+
+      - name: Lint Extension
+        run: yarn run lint
+
+      - name: Build an Package Extension
+        run: |
+          yarn run build:package
+          mv dist/pano@elhan.io.zip .
+
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: pano@elhan.io.zip


### PR DESCRIPTION

## Description

This adds a CI, that runs on release and uploads the extension to it. So it doesn't have to be done manually.
It was tested on my fork, see here: https://github.com/Totto16/gnome-shell-pano/releases and here https://github.com/Totto16/gnome-shell-pano/actions/runs/13474922399

## Type of change


- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] My commits follow the commit standards of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
