### PR TITLE
fix: support older node version than 22.12.0

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+engine-strict=true
+package-manager-strict=true

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "license": "GPL-2.0-or-later",
   "scripts": {
     "build": "yarn run build:ts && yarn run gen:locale && yarn run build:extension",
-    "gen:locale": "yarn run ts-node scripts/generateLocale.ts",
-    "check:locale": "yarn run ts-node scripts/generateLocale.ts --dry-run",
+    "gen:locale": "NODE_OPTIONS='--experimental-require-module' yarn run ts-node scripts/generateLocale.ts",
+    "check:locale": "NODE_OPTIONS='--experimental-require-module' yarn run ts-node scripts/generateLocale.ts --dry-run",
     "build:ts": "yarn run clean:ts && rollup -c --failAfterWarnings && sed -i '/setTimeout/d' dist/thirdparty/prismjs.js && sed -i 's/var\\ /let\\ /g' dist/extension.js dist/prefs.js",
     "clean:ts": "rm -rf ./dist",
     "build:extension": "yarn run build:schema",
@@ -33,6 +33,10 @@
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
     }
   },
+  "engines": {
+    "node": ">= 20.17.0 || >= 22.0.0"
+  },
+  "engineStrict": true,
   "devDependencies": {
     "@commitlint/cli": "^19.7.1",
     "@commitlint/config-conventional": "^19.7.1",


### PR DESCRIPTION
## Description

In #342 (https://github.com/oae/gnome-shell-pano/pull/342/commits/8829de89a47cc8814ed3431ef3abd4439e43531a and https://github.com/oae/gnome-shell-pano/pull/342/commits/8a99348a9244c167d12dfe65d7228e9e6d5ad33d) I updated some dependencies, that our locale generation script uses. The updates made them ESM only. I used node v22.14.0  and I didn't notice any problem. But after investigating a failure reported in #347 I found out, that that broke support for older node version than 22.12.0. The reason for this is the following timeline:

 
| node version | change | ref |
|:------:|:-----:|:-----:|
| v20.17.0 | `--experimental-require-module` flag added, default `false`  | [ref](https://nodejs.org/docs/latest-v20.x/api/cli.html#--experimental-require-module) |  
| v22.0.0 | `--experimental-require-module` flag added, default `false` | [ref](https://nodejs.org/docs/latest-v22.x/api/cli.html#--experimental-require-module) |  
| v22.12.0 | `--experimental-require-module` flag defaults to `true`  | [ref](https://nodejs.org/docs/latest-v22.x/api/cli.html#--experimental-require-module) | 

The flag `--experimental-require-module` makes `require()` calls also support ESM modules, which we need, if we want to use the newest versions of some dependencies.

This feature is under active development, but it's stable in the LTS branches of node

So to fix this issue, I added `NODE_OPTIONS='--experimental-require-module'` in front of every ts-node call. I also guarded everything with an explicit `engines` field in the package.json. So we support only the node versions, where this feature can be enabled. I made the engines field strict, so that it can't be circumvented.

This shouldn't introduce problems, as we use node 22 in actions anyway, and we just use this to generate locales.

Fixes #347 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] My commits follow the commit standards of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
