### PR TITLE
Add notification initialization system to enable notification grouping

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,7 +21,13 @@ import {
   removeSoundContext,
   setupAppDirs,
 } from '@pano/utils/shell';
-import { addTopChrome, removeChrome, removeVirtualKeyboard } from '@pano/utils/ui';
+import {
+  addTopChrome,
+  destroyNotifications,
+  initNotifications,
+  removeChrome,
+  removeVirtualKeyboard,
+} from '@pano/utils/ui';
 
 import { setUnredirectForDisplay } from './utils/shell_compatibility';
 
@@ -51,6 +57,7 @@ export default class PanoExtension extends Extension {
   override enable() {
     this.settings = getCurrentExtensionSettings(this);
     this.setupResources();
+    initNotifications(this);
     this.keyManager = new KeyManager(this);
     this.clipboardManager = new ClipboardManager(this);
     this.indicator = new PanoIndicator(this, this.clearHistory.bind(this), () => this.panoWindow?.toggle());
@@ -65,6 +72,7 @@ export default class PanoExtension extends Extension {
     this.stop();
     this.disableDbus();
     this.indicator?.disable();
+    destroyNotifications();
     this.settings = null;
     this.keyManager = null;
     this.clipboardManager = null;

--- a/src/utils/ui.ts
+++ b/src/utils/ui.ts
@@ -17,6 +17,19 @@ import { setBytesCompat } from './shell_compatibility';
 
 const global = Shell.Global.get();
 
+// Shared MessageTraySource for notification grouping
+let messageSource: MessageTraySource | null = null;
+
+export const initNotifications = (ext: ExtensionBase): void => {
+  const _ = gettext(ext);
+  messageSource = newMessageTraySource(_('Pano'), 'edit-copy-symbolic');
+  main.messageTray.add(messageSource as MessageTraySource);
+};
+
+export const destroyNotifications = (): void => {
+  messageSource = null;
+};
+
 export const notify = (
   ext: ExtensionBase,
   text: string,
@@ -24,9 +37,11 @@ export const notify = (
   iconOrPixbuf?: GdkPixbuf.Pixbuf | Gio.Icon,
   pixelFormat?: Cogl.PixelFormat,
 ): void => {
-  const _ = gettext(ext);
-  const source = newMessageTraySource(_('Pano'), 'edit-copy-symbolic');
-  main.messageTray.add(source as MessageTraySource);
+  if (!messageSource) {
+    initNotifications(ext);
+  }
+
+  const source = messageSource!;
   let notification: Notification;
   if (iconOrPixbuf) {
     if (iconOrPixbuf instanceof GdkPixbuf.Pixbuf) {


### PR DESCRIPTION
## Description

This change adds proper init/destroy of a shared notification source (a requirement for GNOME 48+ notification grouping) to improve message grouping in the system tray.
Any feedback, suggestions, changes or tips by maintainers, contributors etc are welcome.

Fixes #366

UPDATE1: Upon further testing, the change in commit cb19fb6cf7d27728bbea25871efd1c3d7ce7c002 results in individual notification groups for each login session (e.g. if you lock the screen and log back in, a new group of Pano notifications will be created). Perhaps something like a global notification source could address this.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] My commits follow the commit standards of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have checked my code and corrected any misspellings
