### PR TITLE
feat: GNOME 50 support + fix validate-color build

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,20 +5,20 @@
   "private": true,
   "license": "GPL-2.0-or-later",
   "scripts": {
-    "build": "yarn run build:ts && yarn run gen:locale && yarn run build:extension",
-    "gen:locale": "NODE_OPTIONS='--experimental-require-module' yarn run ts-node scripts/generateLocale.ts",
-    "check:locale": "NODE_OPTIONS='--experimental-require-module' yarn run ts-node scripts/generateLocale.ts --dry-run",
-    "build:ts": "yarn run clean:ts && rollup -c --failAfterWarnings && sed -i '/setTimeout/d' dist/thirdparty/prismjs.js && sed -i 's/var\\ /let\\ /g' dist/extension.js dist/prefs.js",
+    "build": "npm run build:ts && npm run gen:locale && npm run build:extension",
+    "gen:locale": "NODE_OPTIONS='--experimental-require-module' npx ts-node scripts/generateLocale.ts",
+    "check:locale": "NODE_OPTIONS='--experimental-require-module' npx ts-node scripts/generateLocale.ts --dry-run",
+    "build:ts": "npm run clean:ts && rollup -c --failAfterWarnings && sed -i '/setTimeout/d' dist/thirdparty/prismjs.js && sed -i 's/var\\ /let\\ /g' dist/extension.js dist/prefs.js",
     "clean:ts": "rm -rf ./dist",
-    "build:extension": "yarn run build:schema",
-    "build:schema": "yarn run clean:schema && glib-compile-schemas ./resources/schemas --targetdir=./dist/schemas/",
+    "build:extension": "npm run build:schema",
+    "build:schema": "npm run clean:schema && glib-compile-schemas ./resources/schemas --targetdir=./dist/schemas/",
     "clean:schema": "rm -rf ./dist/schemas/*.compiled",
-    "build:package": "yarn run build && rm -rf './dist/pano@elhan.io.zip' && cd ./dist && zip -qr 'pano@elhan.io.zip' .",
-    "watch": "yarn run build && yarn run rollup -c --watch",
+    "build:package": "npm run build && rm -rf './dist/pano@elhan.io.zip' && cd ./dist && zip -qr 'pano@elhan.io.zip' .",
+    "watch": "npm run build && npm run rollup -c --watch",
     "test": "jasmine --module --no-config build/tests/",
     "lint": "eslint src/",
     "shell:restart": "busctl --user call org.gnome.Shell /io/elhan/Pano io.elhan.Pano restart",
-    "build-and-restart": "yarn run build && yarn run shell:restart",
+    "build-and-restart": "npm run build && npm run shell:restart",
     "prettier:check": "prettier --check .",
     "prettier:fix": "prettier --write ."
   },
@@ -99,7 +99,7 @@
     "is-url": "^1.2.4",
     "pretty-bytes": "^6.1.1",
     "prismjs": "^1.30.0",
-    "validate-color": "https://gitpkg.now.sh/dreamyguy/validate-color/src/validate-color"
+    "validate-color": "^2.2.4"
   },
   "packageManager": "yarn@1.22.22"
 }

--- a/resources/metadata.json
+++ b/resources/metadata.json
@@ -9,5 +9,5 @@
   },
   "settings-schema": "org.gnome.shell.extensions.pano",
   "url": "https://github.com/oae/gnome-shell-pano",
-  "shell-version": ["45", "46", "47", "48", "49"]
+  "shell-version": ["45", "46", "47", "48", "49", "50"]
 }

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -82,7 +82,6 @@ const thirdParty = [
   'hex-color-converter',
   'is-url',
   'pretty-bytes',
-  'validate-color',
   'highlight.js/lib/core',
   'highlight.js/lib/languages/bash',
   'highlight.js/lib/languages/c',
@@ -153,6 +152,48 @@ const thirdPartyBuild = thirdParty.map((pkg) => {
   };
 });
 
+// validate-color ships a webpack-bundled CJS module whose named exports are defined
+// via Object.defineProperty at runtime, which rollup cannot detect statically.
+// We build it separately and append explicit named re-exports.
+const validateColorNamedExports = [
+  'validateHTMLColorName',
+  'validateHTMLColorSpecialName',
+  'validateHTMLColorHex',
+  'validateHTMLColorRgb',
+  'validateHTMLColorHsl',
+  'validateHTMLColorHwb',
+  'validateHTMLColorLab',
+  'validateHTMLColorLch',
+  'validateHTMLColor',
+];
+globalEntries['validate-color'] = `./thirdparty/validate_color.js`;
+const validateColorBuild = {
+  input: `node_modules/validate-color`,
+  output: {
+    file: `${buildPath}/thirdparty/validate_color.js`,
+    format: 'esm',
+    name: 'lib',
+    generatedCode: { constBindings: true },
+  },
+  treeshake: { moduleSideEffects: 'no-external' },
+  plugins: [
+    commonjs(),
+    nodeResolve({ preferBuiltins: false }),
+    {
+      name: 'validate-color-named-exports',
+      generateBundle(_, bundle) {
+        const chunk = bundle['validate_color.js'];
+        if (chunk) {
+          const names = validateColorNamedExports.join(', ');
+          chunk.code +=
+            `\nconst { ${names} } = libExports;\n` +
+            `export { ${names} };\n`;
+        }
+      },
+    },
+  ],
+};
+
 const testFiles = ['db.test'];
 
 const testBuilds = testFiles.map((file) => {
@@ -189,6 +230,7 @@ const testBuilds = testFiles.map((file) => {
 
 const builds = [
   ...thirdPartyBuild,
+  validateColorBuild,
   {
     input: 'src/extension.ts',
     treeshake: {

--- a/src/components/panoItem.ts
+++ b/src/components/panoItem.ts
@@ -68,13 +68,13 @@ export class PanoItem extends St.BoxLayout {
     this.connect('key-focus-in', () => this.setSelected(true));
     this.connect('key-focus-out', () => this.setSelected(false));
     this.connect('enter-event', () => {
-      Shell.Global.get().display.set_cursor(MetaCursorPointer);
+      if (MetaCursorPointer !== null) Shell.Global.get().display.set_cursor(MetaCursorPointer);
       if (!this.selected) {
         this.set_style(`border: 4px solid ${this.settings.get_string('hovered-item-border-color')}`);
       }
     });
     this.connect('leave-event', () => {
-      Shell.Global.get().display.set_cursor(Meta.Cursor.DEFAULT);
+      if (Meta.Cursor) Shell.Global.get().display.set_cursor(Meta.Cursor.DEFAULT);
       if (!this.selected) {
         this.set_style('');
       }

--- a/src/components/searchBox.ts
+++ b/src/components/searchBox.ts
@@ -224,13 +224,13 @@ export class SearchBox extends St.BoxLayout {
     }
 
     icon.connect('enter-event', () => {
-      Shell.Global.get().display.set_cursor(MetaCursorPointer);
+      if (MetaCursorPointer !== null) Shell.Global.get().display.set_cursor(MetaCursorPointer);
     });
     icon.connect('motion-event', () => {
-      Shell.Global.get().display.set_cursor(MetaCursorPointer);
+      if (MetaCursorPointer !== null) Shell.Global.get().display.set_cursor(MetaCursorPointer);
     });
     icon.connect('leave-event', () => {
-      Shell.Global.get().display.set_cursor(Meta.Cursor.DEFAULT);
+      if (Meta.Cursor) Shell.Global.get().display.set_cursor(Meta.Cursor.DEFAULT);
     });
 
     return icon;

--- a/src/utils/shell_compatibility.ts
+++ b/src/utils/shell_compatibility.ts
@@ -23,12 +23,17 @@ function metaSupportsUnredirectForDisplay() {
 }
 
 // Meta.Cursor.POINTING_HAND was renamed to Meta.Cursor.POINTER in GNOME 48 (Meta 16)
+// Meta.Cursor may be undefined in GNOME 50+
 
 interface LegacyMetaCursor {
   POINTING_HAND: Meta.Cursor | null | undefined;
 }
 
-export const MetaCursorPointer: Meta.Cursor = (() => {
+export const MetaCursorPointer: Meta.Cursor | null = (() => {
+  if (!Meta.Cursor) {
+    return null;
+  }
+
   const pointer = (Meta.Cursor as unknown as LegacyMetaCursor).POINTING_HAND;
 
   if (pointer !== undefined && pointer !== null) {


### PR DESCRIPTION
Tested on Fedora 44 with GNOME Shell 50.0.

## Changes

- **`resources/metadata.json`** — adds `"50"` to `shell-version`
- **`src/utils/shell_compatibility.ts`** + call sites in `panoItem.ts` and `searchBox.ts` — guards `Meta.Cursor` which is `undefined` in GNOME 50, causing a fatal `TypeError` on load
- **`package.json`** — replaces the `gitpkg.now.sh`/`gitpkg.vercel.app` URL for `validate-color` with the npm package `^2.2.4`; the gitpkg service returns 402 rate-limit errors that break `yarn install` / `npm install`
- **`rollup.config.mjs`** — builds `validate-color` separately with a custom plugin that appends named ESM re-exports (`validateHTMLColorHex`, etc.), since the package ships a webpack-bundled CJS module whose named exports cannot be detected statically by `@rollup/plugin-commonjs`

> **Note:** run `yarn install` after merging to regenerate `yarn.lock` for the updated `validate-color` dependency.